### PR TITLE
Make it work on Windows-x86

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ native-1c = { git = "https://github.com/tuplecats/rust-native-1c.git" }
 которые использует 1С для подключения компоненты:
 
 ```rust
-unsafe extern "C" fn GetClassObject(_name: *const u16, component: *mut *const u8) -> usize;
-unsafe extern "C" fn DestroyObject(_component: *mut *const u8) -> usize;
+unsafe extern "C" fn GetClassObject(_name: *const u16, component: *mut *const u8) -> std::os::raw::c_long;
+unsafe extern "C" fn DestroyObject(_component: *mut *const u8) -> std::os::raw::c_long;
 unsafe extern "C" fn GetClassNames() -> *const u16;
 unsafe extern "C" fn SetPlatformCapabilities(capabilities: AppCapabilities) -> AppCapabilities;
 ```
@@ -35,25 +35,25 @@ unsafe extern "C" fn SetPlatformCapabilities(capabilities: AppCapabilities) -> A
 pub trait IComponentBase {
     // IInitDoneBaseVTable
     fn init(&mut self) -> bool;
-    fn get_info(&self) -> i64;
+    fn get_info(&self) -> i32;
     fn done(&mut self);
 
     // ILanguageExtenderBaseVTable
-    fn get_n_props(&self) -> i64;
-    fn find_prop(&self, prop_name: &str) -> i64;
-    fn get_prop_name(&self, prop_num: i64, prop_alias: i64) -> &str;
-    fn get_prop_val(&self, prop_num: i64, var_prop_val: &mut Variant) -> bool;
-    fn set_prop_val(&mut self, prop_num: i64, var_prop_val: &Variant) -> bool;
-    fn is_prop_readable(&self, prop_num: i64) -> bool;
-    fn is_prop_writeable(&self, prop_num: i64) -> bool;
-    fn get_n_methods(&self) -> i64;
-    fn find_method(&self, method_name: &str) -> i64;
-    fn get_method_name(&self, method_num: i64, method_alias: i64) -> &str;
-    fn get_n_params(&self, method_num: i64) -> i64;
-    fn get_param_def_value(&self, method_num: i64, param_num: i64, var_param_def_value: &mut Variant) -> bool;
-    fn has_ret_val(&self, method_num: i64) -> bool;
-    fn call_as_proc(&mut self, method_num: i64, params: Option<&mut [Variant]>) -> bool;
-    fn call_as_func(&mut self, method_num: i64, ret_vals: &mut Variant, params: Option<&mut [Variant]>) -> bool;
+    fn get_n_props(&self) -> i32;
+    fn find_prop(&self, prop_name: &str) -> i32;
+    fn get_prop_name(&self, prop_num: i32, prop_alias: i32) -> &str;
+    fn get_prop_val(&self, prop_num: i32, var_prop_val: &mut Variant) -> bool;
+    fn set_prop_val(&mut self, prop_num: i32, var_prop_val: &Variant) -> bool;
+    fn is_prop_readable(&self, prop_num: i32) -> bool;
+    fn is_prop_writeable(&self, prop_num: i32) -> bool;
+    fn get_n_methods(&self) -> i32;
+    fn find_method(&self, method_name: &str) -> i32;
+    fn get_method_name(&self, method_num: i32, method_alias: i32) -> &str;
+    fn get_n_params(&self, method_num: i32) -> i32;
+    fn get_param_def_value(&self, method_num: i32, param_num: i32, var_param_def_value: &mut Variant) -> bool;
+    fn has_ret_val(&self, method_num: i32) -> bool;
+    fn call_as_proc(&mut self, method_num: i32, params: Option<&mut [Variant]>) -> bool;
+    fn call_as_func(&mut self, method_num: i32, ret_vals: &mut Variant, params: Option<&mut [Variant]>) -> bool;
 
     // LocaleBaseVTable
     fn set_locale(&mut self, loc: &str);

--- a/examples/simple_example/src/addin_test.rs
+++ b/examples/simple_example/src/addin_test.rs
@@ -15,17 +15,17 @@ impl IComponentBase for TestAddIn {
         true
     }
 
-    fn get_info(&self) -> i64 {
+    fn get_info(&self) -> i32 {
         1000
     }
 
     fn done(&mut self) {}
 
-    fn get_n_props(&self) -> i64 {
+    fn get_n_props(&self) -> i32 {
         2
     }
 
-    fn find_prop(&self, prop_name: &str) -> i64 {
+    fn find_prop(&self, prop_name: &str) -> i32 {
         match prop_name {
             "ТестовоеСвойство" | "TestProp" => 0,
             "СтроковоеСвойство" | "StringProp" => 1,
@@ -33,7 +33,7 @@ impl IComponentBase for TestAddIn {
         }
     }
 
-    fn get_prop_name(&self, prop_num: i64, prop_alias: i64) -> &str {
+    fn get_prop_name(&self, prop_num: i32, prop_alias: i32) -> &str {
         match prop_num {
             0 => {
                 if prop_alias == 0 {
@@ -53,7 +53,7 @@ impl IComponentBase for TestAddIn {
         }
     }
 
-    fn get_prop_val(&self, prop_num: i64, var_prop_val: &mut Variant) -> bool {
+    fn get_prop_val(&self, prop_num: i32, var_prop_val: &mut Variant) -> bool {
         match prop_num {
             0 => {
                 *var_prop_val = Variant::from(self.num_prop);
@@ -66,7 +66,7 @@ impl IComponentBase for TestAddIn {
         true
     }
 
-    fn set_prop_val(&mut self, prop_num: i64, var_prop_val: &Variant) -> bool {
+    fn set_prop_val(&mut self, prop_num: i32, var_prop_val: &Variant) -> bool {
         match prop_num {
             0 => match var_prop_val.as_i32() {
                 Some(value) => self.num_prop = value,
@@ -80,26 +80,26 @@ impl IComponentBase for TestAddIn {
         }
         true
     }
-    fn is_prop_readable(&self, _prop_num: i64) -> bool {
+    fn is_prop_readable(&self, _prop_num: i32) -> bool {
         true
     }
 
-    fn is_prop_writeable(&self, _prop_num: i64) -> bool {
+    fn is_prop_writeable(&self, _prop_num: i32) -> bool {
         true
     }
 
-    fn get_n_methods(&self) -> i64 {
+    fn get_n_methods(&self) -> i32 {
         2
     }
 
-    fn find_method(&self, method_name: &str) -> i64 {
+    fn find_method(&self, method_name: &str) -> i32 {
         match method_name {
             "ИнформацияОСистеме" | "SystemInfo" => 0,
             "ПоказатьОкноСИнформацией" | "ShowInfoWindow" => 1,
             _ => unreachable!(),
         }
     }
-    fn get_method_name(&self, method_num: i64, method_alias: i64) -> &str {
+    fn get_method_name(&self, method_num: i32, method_alias: i32) -> &str {
         match method_num {
             0 => {
                 if method_alias == 0 {
@@ -118,7 +118,7 @@ impl IComponentBase for TestAddIn {
             _ => unreachable!(),
         }
     }
-    fn get_n_params(&self, method_num: i64) -> i64 {
+    fn get_n_params(&self, method_num: i32) -> i32 {
         match method_num {
             0 => 3,
             1 => 1,
@@ -127,8 +127,8 @@ impl IComponentBase for TestAddIn {
     }
     fn get_param_def_value(
         &self,
-        method_num: i64,
-        param_num: i64,
+        method_num: i32,
+        param_num: i32,
         var_param_def_value: &mut Variant,
     ) -> bool {
         match method_num {
@@ -139,17 +139,17 @@ impl IComponentBase for TestAddIn {
         }
         true
     }
-    fn has_ret_val(&self, _method_num: i64) -> bool {
+    fn has_ret_val(&self, _method_num: i32) -> bool {
         true
     }
 
-    fn call_as_proc(&mut self, _method_num: i64, _params: Option<&mut [Variant]>) -> bool {
+    fn call_as_proc(&mut self, _method_num: i32, _params: Option<&mut [Variant]>) -> bool {
         true
     }
 
     fn call_as_func(
         &mut self,
-        method_num: i64,
+        method_num: i32,
         ret_vals: &mut Variant,
         params: Option<&mut [Variant]>,
     ) -> bool {

--- a/examples/simple_example/src/lib.rs
+++ b/examples/simple_example/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(let_else)]
+use std::os::raw::c_long;
 use native_1c::OnceCell;
 use native_1c::component::AppCapabilities;
 use native_1c::widestring::{U16CStr, U16CString};
@@ -9,17 +10,17 @@ mod addin_test;
 static CLASS_NAMES: OnceCell<Vec<u16>> = OnceCell::new();
 
 #[no_mangle]
-unsafe extern "C" fn GetClassObject(_name: *const u16, component: *mut *const u8) -> usize {
+unsafe extern "C" fn GetClassObject(_name: *const u16, component: *mut *const u8) -> c_long {
     let Ok(name) = U16CStr::from_ptr_str(_name).to_string() else { return 0 };
     *component = match name.as_str() {
         "TestAddIn" => Box::into_raw(Box::new(TestAddIn::new())) as *const u8,
         _ => return 0
     };
-    component as usize
+    component as c_long
 }
 
 #[no_mangle]
-unsafe extern "C" fn DestroyObject(_component: *mut *const u8) -> usize {
+unsafe extern "C" fn DestroyObject(_component: *mut *const u8) -> c_long {
     0
 }
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -36,31 +36,31 @@ pub fn native_object(_args: TokenStream, input: TokenStream) -> TokenStream {
             #[cfg(target_os = "linux")]
             offset_linux: 0,
             drop: {
-                unsafe extern "stdcall" fn drop<T: IComponentBase>(_0: &mut T) {
+                unsafe extern "system" fn drop<T: IComponentBase>(_0: &mut T) {
 
                 }
                 drop::<#ident>
             },
             init: {
-                unsafe extern "stdcall" fn init<T: IComponentInit>(_0: &mut T, disp: *mut c_void) -> bool {
+                unsafe extern "system" fn init<T: IComponentInit>(_0: &mut T, disp: *mut c_void) -> bool {
                     _0._init(disp)
                 }
                 init::<#ident>
             },
             set_mem_manager: {
-                unsafe extern "stdcall" fn set_mem_manager<T: IComponentInit>(_0: &mut T, mem: *mut c_void) -> bool {
+                unsafe extern "system" fn set_mem_manager<T: IComponentInit>(_0: &mut T, mem: *mut c_void) -> bool {
                     _0.set_mem_manager(mem)
                 }
                 set_mem_manager::<#ident>
             },
             get_info: {
-                unsafe extern "stdcall" fn get_info<T: IComponentBase>(_0: &T) -> std::ffi::c_long {
+                unsafe extern "system" fn get_info<T: IComponentBase>(_0: &T) -> std::os::raw::c_long {
                     _0.get_info()
                 }
                 get_info::<#ident>
             },
             done: {
-                unsafe extern "stdcall" fn done<T: IComponentBase>(_0: &mut T) {
+                unsafe extern "system" fn done<T: IComponentBase>(_0: &mut T) {
                     _0.done();
                 }
                 done::<#ident>
@@ -72,119 +72,119 @@ pub fn native_object(_args: TokenStream, input: TokenStream) -> TokenStream {
             #[cfg(target_os = "linux")]
             offset_linux: 0,
             drop: {
-                unsafe extern "stdcall" fn drop<T: IComponentBase>(_0: &mut T) {
+                unsafe extern "system" fn drop<T: IComponentBase>(_0: &mut T) {
 
                 }
                 drop::<#ident>
             },
             register_extension_as: {
-                unsafe extern "stdcall" fn register_extension_as<T: IComponentInit>(_0: &mut T, name: *mut *const u16) -> bool {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
+                unsafe extern "system" fn register_extension_as<T: IComponentInit>(_0: &mut T, name: *mut *const u16) -> bool {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<usize>()) as *mut T);
                     _0.register_extension_as(name)
                 }
                 register_extension_as::<#ident>
             },
             get_n_props: {
-                unsafe extern "stdcall" fn get_n_props<T: IComponentBase>(_0: &mut T) -> std::ffi::c_long {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
+                unsafe extern "system" fn get_n_props<T: IComponentBase>(_0: &mut T) -> std::os::raw::c_long {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<usize>()) as *mut T);
                     _0.get_n_props()
                 }
                 get_n_props::<#ident>
             },
             find_prop: {
-                unsafe extern "stdcall" fn find_prop<T: IComponentBase>(_0: &mut T, name: *const u16) -> std::ffi::c_long {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
+                unsafe extern "system" fn find_prop<T: IComponentBase>(_0: &mut T, name: *const u16) -> std::os::raw::c_long {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<usize>()) as *mut T);
                     let prop_name = unsafe { widestring::U16CStr::from_ptr_str(name).to_string().unwrap() };
                     _0.find_prop(prop_name.as_str())
                 }
                 find_prop::<#ident>
             },
             get_prop_name: {
-                unsafe extern "stdcall" fn get_prop_name<T: IComponentBase + IComponentInit>(_0: &T, num: std::ffi::c_long, alias: std::ffi::c_long) -> *const u16 {
-                    let _0 = &*((((_0 as *const T) as *const u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *const T);
+                unsafe extern "system" fn get_prop_name<T: IComponentBase + IComponentInit>(_0: &T, num: std::os::raw::c_long, alias: std::os::raw::c_long) -> *const u16 {
+                    let _0 = &*((((_0 as *const T) as *const u8) as usize - std::mem::size_of::<usize>()) as *const T);
                     let prop_name = _0.get_prop_name(num, alias);
                     _0.mem_manager().copy_utf16_str(prop_name)
                 }
                 get_prop_name::<#ident>
             },
             get_prop_val: {
-                unsafe extern "stdcall" fn get_prop_val<T: IComponentBase>(_0: &mut T, num: std::ffi::c_long, value: *mut Variant) -> bool {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
+                unsafe extern "system" fn get_prop_val<T: IComponentBase>(_0: &mut T, num: std::os::raw::c_long, value: *mut Variant) -> bool {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<usize>()) as *mut T);
                     let value = &mut *value;
                     _0.get_prop_val(num, value)
                 }
                 get_prop_val::<#ident>
             },
             set_prop_val: {
-                unsafe extern "stdcall" fn set_prop_val<T: IComponentBase>(_0: &mut T, num: std::ffi::c_long, value: *mut Variant) -> bool {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
+                unsafe extern "system" fn set_prop_val<T: IComponentBase>(_0: &mut T, num: std::os::raw::c_long, value: *mut Variant) -> bool {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<usize>()) as *mut T);
                     let value = &*value;
                     _0.set_prop_val(num, value)
                 }
                 set_prop_val::<#ident>
             },
             is_prop_readable: {
-                unsafe extern "stdcall" fn is_prop_readable<T: IComponentBase>(_0: &mut T, num: std::ffi::c_long) -> bool {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
+                unsafe extern "system" fn is_prop_readable<T: IComponentBase>(_0: &mut T, num: std::os::raw::c_long) -> bool {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<usize>()) as *mut T);
                     _0.is_prop_readable(num)
                 }
                 is_prop_readable::<#ident>
             },
             is_prop_writeable: {
-                unsafe extern "stdcall" fn is_prop_writeable<T: IComponentBase>(_0: &mut T, num: std::ffi::c_long) -> bool {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
+                unsafe extern "system" fn is_prop_writeable<T: IComponentBase>(_0: &mut T, num: std::os::raw::c_long) -> bool {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<usize>()) as *mut T);
                     _0.is_prop_writeable(num)
                 }
                 is_prop_writeable::<#ident>
             },
             get_n_methods: {
-                unsafe extern "stdcall" fn get_n_methods<T: IComponentBase>(_0: &mut T) -> std::ffi::c_long {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
+                unsafe extern "system" fn get_n_methods<T: IComponentBase>(_0: &mut T) -> std::os::raw::c_long {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<usize>()) as *mut T);
                     _0.get_n_methods()
                 }
                 get_n_methods::<#ident>
             },
             find_method: {
-                unsafe extern "stdcall" fn find_method<T: IComponentBase>(_0: &mut T, name: *const u16) -> std::ffi::c_long {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
+                unsafe extern "system" fn find_method<T: IComponentBase>(_0: &mut T, name: *const u16) -> std::os::raw::c_long {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<usize>()) as *mut T);
                     let method_name = unsafe { widestring::U16CStr::from_ptr_str(name).to_string().unwrap() };
                     _0.find_method(method_name.as_str())
                 }
                 find_method::<#ident>
             },
             get_method_name: {
-                unsafe extern "stdcall" fn get_method_name<T: IComponentBase + IComponentInit>(_0: &T, num: std::ffi::c_long, alias: std::ffi::c_long) -> *const u16 {
-                    let _0 = &*((((_0 as *const T) as *const u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *const T);
+                unsafe extern "system" fn get_method_name<T: IComponentBase + IComponentInit>(_0: &T, num: std::os::raw::c_long, alias: std::os::raw::c_long) -> *const u16 {
+                    let _0 = &*((((_0 as *const T) as *const u8) as usize - std::mem::size_of::<usize>()) as *const T);
                     let method_name = _0.get_method_name(num, alias);
                     _0.mem_manager().copy_utf16_str(method_name)
                 }
                 get_method_name::<#ident>
             },
             get_n_params: {
-                unsafe extern "stdcall" fn get_n_params<T: IComponentBase>(_0: &mut T, num: std::ffi::c_long) -> std::ffi::c_long {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
+                unsafe extern "system" fn get_n_params<T: IComponentBase>(_0: &mut T, num: std::os::raw::c_long) -> std::os::raw::c_long {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<usize>()) as *mut T);
                     _0.get_n_params(num)
                 }
                 get_n_params::<#ident>
             },
             get_param_def_value: {
-                unsafe extern "stdcall" fn get_param_def_value<T: IComponentBase>(_0: &mut T, num: std::ffi::c_long, param_num: std::ffi::c_long, value: *mut Variant) -> bool {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
+                unsafe extern "system" fn get_param_def_value<T: IComponentBase>(_0: &mut T, num: std::os::raw::c_long, param_num: std::os::raw::c_long, value: *mut Variant) -> bool {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<usize>()) as *mut T);
                     let value = &mut *value;
                     _0.get_param_def_value(num, param_num, value)
                 }
                 get_param_def_value::<#ident>
             },
             has_ret_val: {
-                unsafe extern "stdcall" fn has_ret_val<T: IComponentBase>(_0: &mut T, num: std::ffi::c_long) -> bool {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
+                unsafe extern "system" fn has_ret_val<T: IComponentBase>(_0: &mut T, num: std::os::raw::c_long) -> bool {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<usize>()) as *mut T);
                     _0.has_ret_val(num)
                 }
                 has_ret_val::<#ident>
             },
             call_as_proc: {
-                unsafe extern "stdcall" fn call_as_proc<T: IComponentBase>(_0: &mut T, num: std::ffi::c_long, params: *mut Variant, size: std::ffi::c_long) -> bool {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
+                unsafe extern "system" fn call_as_proc<T: IComponentBase>(_0: &mut T, num: std::os::raw::c_long, params: *mut Variant, size: std::os::raw::c_long) -> bool {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<usize>()) as *mut T);
                     let params = match params.is_null() {
                         true => None,
                         false => Some(std::slice::from_raw_parts_mut(params, size as usize))
@@ -194,8 +194,8 @@ pub fn native_object(_args: TokenStream, input: TokenStream) -> TokenStream {
                 call_as_proc::<#ident>
             },
             call_as_func: {
-                unsafe extern "stdcall" fn call_as_func<T: IComponentBase>(_0: &mut T, num: std::ffi::c_long, ret: *mut Variant, params: *mut Variant, size: std::ffi::c_long) -> bool {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
+                unsafe extern "system" fn call_as_func<T: IComponentBase>(_0: &mut T, num: std::os::raw::c_long, ret: *mut Variant, params: *mut Variant, size: std::os::raw::c_long) -> bool {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<usize>()) as *mut T);
                     let params = match params.is_null() {
                         true => None,
                         false => Some(std::slice::from_raw_parts_mut(params, size as usize))
@@ -213,14 +213,14 @@ pub fn native_object(_args: TokenStream, input: TokenStream) -> TokenStream {
             #[cfg(target_os = "linux")]
             offset_linux: 0,
             drop: {
-                unsafe extern "stdcall" fn drop<T: IComponentBase>(_0: &mut T) {
+                unsafe extern "system" fn drop<T: IComponentBase>(_0: &mut T) {
 
                 }
                 drop::<#ident>
             },
             set_locale: {
-                unsafe extern "stdcall" fn set_locale<T: IComponentBase>(_0: &mut T, loc: *const u16) {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()*2) as *mut T);
+                unsafe extern "system" fn set_locale<T: IComponentBase>(_0: &mut T, loc: *const u16) {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<usize>()*2) as *mut T);
                     let locale = unsafe { widestring::U16CStr::from_ptr_str(loc).to_string().unwrap() };
                     _0.set_locale(locale.as_str());
                 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -36,31 +36,31 @@ pub fn native_object(_args: TokenStream, input: TokenStream) -> TokenStream {
             #[cfg(target_os = "linux")]
             offset_linux: 0,
             drop: {
-                unsafe extern "C" fn drop<T: IComponentBase>(_0: &mut T) {
+                unsafe extern "stdcall" fn drop<T: IComponentBase>(_0: &mut T) {
 
                 }
                 drop::<#ident>
             },
             init: {
-                unsafe extern "C" fn init<T: IComponentInit>(_0: &mut T, disp: *mut c_void) -> bool {
+                unsafe extern "stdcall" fn init<T: IComponentInit>(_0: &mut T, disp: *mut c_void) -> bool {
                     _0._init(disp)
                 }
                 init::<#ident>
             },
             set_mem_manager: {
-                unsafe extern "C" fn set_mem_manager<T: IComponentInit>(_0: &mut T, mem: *mut c_void) -> bool {
+                unsafe extern "stdcall" fn set_mem_manager<T: IComponentInit>(_0: &mut T, mem: *mut c_void) -> bool {
                     _0.set_mem_manager(mem)
                 }
                 set_mem_manager::<#ident>
             },
             get_info: {
-                unsafe extern "C" fn get_info<T: IComponentBase>(_0: &T) -> i64 {
+                unsafe extern "stdcall" fn get_info<T: IComponentBase>(_0: &T) -> std::ffi::c_long {
                     _0.get_info()
                 }
                 get_info::<#ident>
             },
             done: {
-                unsafe extern "C" fn done<T: IComponentBase>(_0: &mut T) {
+                unsafe extern "stdcall" fn done<T: IComponentBase>(_0: &mut T) {
                     _0.done();
                 }
                 done::<#ident>
@@ -72,133 +72,133 @@ pub fn native_object(_args: TokenStream, input: TokenStream) -> TokenStream {
             #[cfg(target_os = "linux")]
             offset_linux: 0,
             drop: {
-                unsafe extern "C" fn drop<T: IComponentBase>(_0: &mut T) {
+                unsafe extern "stdcall" fn drop<T: IComponentBase>(_0: &mut T) {
 
                 }
                 drop::<#ident>
             },
             register_extension_as: {
-                unsafe extern "C" fn register_extension_as<T: IComponentInit>(_0: &mut T, name: *mut *const u16) -> bool {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - 8) as *mut T);
+                unsafe extern "stdcall" fn register_extension_as<T: IComponentInit>(_0: &mut T, name: *mut *const u16) -> bool {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
                     _0.register_extension_as(name)
                 }
                 register_extension_as::<#ident>
             },
             get_n_props: {
-                unsafe extern "C" fn get_n_props<T: IComponentBase>(_0: &mut T) -> i64 {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - 8) as *mut T);
+                unsafe extern "stdcall" fn get_n_props<T: IComponentBase>(_0: &mut T) -> std::ffi::c_long {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
                     _0.get_n_props()
                 }
                 get_n_props::<#ident>
             },
             find_prop: {
-                unsafe extern "C" fn find_prop<T: IComponentBase>(_0: &mut T, name: *const u16) -> i64 {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - 8) as *mut T);
+                unsafe extern "stdcall" fn find_prop<T: IComponentBase>(_0: &mut T, name: *const u16) -> std::ffi::c_long {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
                     let prop_name = unsafe { widestring::U16CStr::from_ptr_str(name).to_string().unwrap() };
                     _0.find_prop(prop_name.as_str())
                 }
                 find_prop::<#ident>
             },
             get_prop_name: {
-                unsafe extern "C" fn get_prop_name<T: IComponentBase + IComponentInit>(_0: &T, num: i64, alias: i64) -> *const u16 {
-                    let _0 = &*((((_0 as *const T) as *const u8) as usize - 8) as *const T);
+                unsafe extern "stdcall" fn get_prop_name<T: IComponentBase + IComponentInit>(_0: &T, num: std::ffi::c_long, alias: std::ffi::c_long) -> *const u16 {
+                    let _0 = &*((((_0 as *const T) as *const u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *const T);
                     let prop_name = _0.get_prop_name(num, alias);
                     _0.mem_manager().copy_utf16_str(prop_name)
                 }
                 get_prop_name::<#ident>
             },
             get_prop_val: {
-                unsafe extern "C" fn get_prop_val<T: IComponentBase>(_0: &mut T, num: i64, value: *mut Variant) -> bool {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - 8) as *mut T);
+                unsafe extern "stdcall" fn get_prop_val<T: IComponentBase>(_0: &mut T, num: std::ffi::c_long, value: *mut Variant) -> bool {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
                     let value = &mut *value;
                     _0.get_prop_val(num, value)
                 }
                 get_prop_val::<#ident>
             },
             set_prop_val: {
-                unsafe extern "C" fn set_prop_val<T: IComponentBase>(_0: &mut T, num: i64, value: *mut Variant) -> bool {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - 8) as *mut T);
+                unsafe extern "stdcall" fn set_prop_val<T: IComponentBase>(_0: &mut T, num: std::ffi::c_long, value: *mut Variant) -> bool {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
                     let value = &*value;
                     _0.set_prop_val(num, value)
                 }
                 set_prop_val::<#ident>
             },
             is_prop_readable: {
-                unsafe extern "C" fn is_prop_readable<T: IComponentBase>(_0: &mut T, num: i64) -> bool {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - 8) as *mut T);
+                unsafe extern "stdcall" fn is_prop_readable<T: IComponentBase>(_0: &mut T, num: std::ffi::c_long) -> bool {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
                     _0.is_prop_readable(num)
                 }
                 is_prop_readable::<#ident>
             },
             is_prop_writeable: {
-                unsafe extern "C" fn is_prop_writeable<T: IComponentBase>(_0: &mut T, num: i64) -> bool {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - 8) as *mut T);
+                unsafe extern "stdcall" fn is_prop_writeable<T: IComponentBase>(_0: &mut T, num: std::ffi::c_long) -> bool {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
                     _0.is_prop_writeable(num)
                 }
                 is_prop_writeable::<#ident>
             },
             get_n_methods: {
-                unsafe extern "C" fn get_n_methods<T: IComponentBase>(_0: &mut T) -> i64 {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - 8) as *mut T);
+                unsafe extern "stdcall" fn get_n_methods<T: IComponentBase>(_0: &mut T) -> std::ffi::c_long {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
                     _0.get_n_methods()
                 }
                 get_n_methods::<#ident>
             },
             find_method: {
-                unsafe extern "C" fn find_method<T: IComponentBase>(_0: &mut T, name: *const u16) -> i64 {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - 8) as *mut T);
+                unsafe extern "stdcall" fn find_method<T: IComponentBase>(_0: &mut T, name: *const u16) -> std::ffi::c_long {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
                     let method_name = unsafe { widestring::U16CStr::from_ptr_str(name).to_string().unwrap() };
                     _0.find_method(method_name.as_str())
                 }
                 find_method::<#ident>
             },
             get_method_name: {
-                unsafe extern "C" fn get_method_name<T: IComponentBase + IComponentInit>(_0: &T, num: i64, alias: i64) -> *const u16 {
-                    let _0 = &*((((_0 as *const T) as *const u8) as usize - 8) as *const T);
+                unsafe extern "stdcall" fn get_method_name<T: IComponentBase + IComponentInit>(_0: &T, num: std::ffi::c_long, alias: std::ffi::c_long) -> *const u16 {
+                    let _0 = &*((((_0 as *const T) as *const u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *const T);
                     let method_name = _0.get_method_name(num, alias);
                     _0.mem_manager().copy_utf16_str(method_name)
                 }
                 get_method_name::<#ident>
             },
             get_n_params: {
-                unsafe extern "C" fn get_n_params<T: IComponentBase>(_0: &mut T, num: i64) -> i64 {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - 8) as *mut T);
+                unsafe extern "stdcall" fn get_n_params<T: IComponentBase>(_0: &mut T, num: std::ffi::c_long) -> std::ffi::c_long {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
                     _0.get_n_params(num)
                 }
                 get_n_params::<#ident>
             },
             get_param_def_value: {
-                unsafe extern "C" fn get_param_def_value<T: IComponentBase>(_0: &mut T, num: i64, param_num: i64, value: *mut Variant) -> bool {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - 8) as *mut T);
+                unsafe extern "stdcall" fn get_param_def_value<T: IComponentBase>(_0: &mut T, num: std::ffi::c_long, param_num: std::ffi::c_long, value: *mut Variant) -> bool {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
                     let value = &mut *value;
                     _0.get_param_def_value(num, param_num, value)
                 }
                 get_param_def_value::<#ident>
             },
             has_ret_val: {
-                unsafe extern "C" fn has_ret_val<T: IComponentBase>(_0: &mut T, num: i64) -> bool {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - 8) as *mut T);
+                unsafe extern "stdcall" fn has_ret_val<T: IComponentBase>(_0: &mut T, num: std::ffi::c_long) -> bool {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
                     _0.has_ret_val(num)
                 }
                 has_ret_val::<#ident>
             },
             call_as_proc: {
-                unsafe extern "C" fn call_as_proc<T: IComponentBase>(_0: &mut T, num: i64, params: *mut Variant, size: usize) -> bool {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - 8) as *mut T);
+                unsafe extern "stdcall" fn call_as_proc<T: IComponentBase>(_0: &mut T, num: std::ffi::c_long, params: *mut Variant, size: std::ffi::c_long) -> bool {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
                     let params = match params.is_null() {
                         true => None,
-                        false => Some(std::slice::from_raw_parts_mut(params, size))
+                        false => Some(std::slice::from_raw_parts_mut(params, size as usize))
                     };
                     _0.call_as_proc(num, params)
                 }
                 call_as_proc::<#ident>
             },
             call_as_func: {
-                unsafe extern "C" fn call_as_func<T: IComponentBase>(_0: &mut T, num: i64, ret: *mut Variant, params: *mut Variant, size: usize) -> bool {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - 8) as *mut T);
+                unsafe extern "stdcall" fn call_as_func<T: IComponentBase>(_0: &mut T, num: std::ffi::c_long, ret: *mut Variant, params: *mut Variant, size: std::ffi::c_long) -> bool {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()) as *mut T);
                     let params = match params.is_null() {
                         true => None,
-                        false => Some(std::slice::from_raw_parts_mut(params, size))
+                        false => Some(std::slice::from_raw_parts_mut(params, size as usize))
                     };
                     let ret = &mut *ret;
 
@@ -213,14 +213,14 @@ pub fn native_object(_args: TokenStream, input: TokenStream) -> TokenStream {
             #[cfg(target_os = "linux")]
             offset_linux: 0,
             drop: {
-                unsafe extern "C" fn drop<T: IComponentBase>(_0: &mut T) {
+                unsafe extern "stdcall" fn drop<T: IComponentBase>(_0: &mut T) {
 
                 }
                 drop::<#ident>
             },
             set_locale: {
-                unsafe extern "C" fn set_locale<T: IComponentBase>(_0: &mut T, loc: *const u16) {
-                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - 16) as *mut T);
+                unsafe extern "stdcall" fn set_locale<T: IComponentBase>(_0: &mut T, loc: *const u16) {
+                    let _0 = &mut *((((_0 as *mut T) as *mut u8) as usize - std::mem::size_of::<std::ffi::c_long>()*2) as *mut T);
                     let locale = unsafe { widestring::U16CStr::from_ptr_str(loc).to_string().unwrap() };
                     _0.set_locale(locale.as_str());
                 }

--- a/src/component.rs
+++ b/src/component.rs
@@ -76,25 +76,25 @@ pub trait IComponentInit where Self: IComponentBase {
 pub trait IComponentBase {
     // IInitDoneBaseVTable
     fn init(&mut self) -> bool;
-    fn get_info(&self) -> c_long;
+    fn get_info(&self) -> i32;
     fn done(&mut self);
 
     // ILanguageExtenderBaseVTable
-    fn get_n_props(&self) -> c_long;
-    fn find_prop(&self, prop_name: &str) -> c_long;
-    fn get_prop_name(&self, prop_num: c_long, prop_alias: c_long) -> &str;
-    fn get_prop_val(&self, prop_num: c_long, var_prop_val: &mut Variant) -> bool;
-    fn set_prop_val(&mut self, prop_num: c_long, var_prop_val: &Variant) -> bool;
-    fn is_prop_readable(&self, prop_num: c_long) -> bool;
-    fn is_prop_writeable(&self, prop_num: c_long) -> bool;
-    fn get_n_methods(&self) -> c_long;
-    fn find_method(&self, method_name: &str) -> c_long;
-    fn get_method_name(&self, method_num: c_long, method_alias: c_long) -> &str;
-    fn get_n_params(&self, method_num: c_long) -> c_long;
-    fn get_param_def_value(&self, method_num: c_long, param_num: c_long, var_param_def_value: &mut Variant) -> bool;
-    fn has_ret_val(&self, method_num: c_long) -> bool;
-    fn call_as_proc(&mut self, method_num: c_long, params: Option<&mut [Variant]>) -> bool;
-    fn call_as_func(&mut self, method_num: c_long, ret_vals: &mut Variant, params: Option<&mut [Variant]>) -> bool;
+    fn get_n_props(&self) -> i32;
+    fn find_prop(&self, prop_name: &str) -> i32;
+    fn get_prop_name(&self, prop_num: i32, prop_alias: i32) -> &str;
+    fn get_prop_val(&self, prop_num: i32, var_prop_val: &mut Variant) -> bool;
+    fn set_prop_val(&mut self, prop_num: i32, var_prop_val: &Variant) -> bool;
+    fn is_prop_readable(&self, prop_num: i32) -> bool;
+    fn is_prop_writeable(&self, prop_num: i32) -> bool;
+    fn get_n_methods(&self) -> i32;
+    fn find_method(&self, method_name: &str) -> i32;
+    fn get_method_name(&self, method_num: i32, method_alias: i32) -> &str;
+    fn get_n_params(&self, method_num: i32) -> i32;
+    fn get_param_def_value(&self, method_num: i32, param_num: i32, var_param_def_value: &mut Variant) -> bool;
+    fn has_ret_val(&self, method_num: i32) -> bool;
+    fn call_as_proc(&mut self, method_num: i32, params: Option<&mut [Variant]>) -> bool;
+    fn call_as_func(&mut self, method_num: i32, ret_vals: &mut Variant, params: Option<&mut [Variant]>) -> bool;
 
     // LocaleBaseVTable
     fn set_locale(&mut self, loc: &str);

--- a/src/component.rs
+++ b/src/component.rs
@@ -101,7 +101,7 @@ pub trait IComponentBase {
 }
 
 #[allow(non_camel_case_types)]
-#[repr(i8)]
+#[repr(i32)]
 pub enum AppCapabilities {
     #[allow(unused)] eAppCapabilitiesInvalid = -1,
     #[allow(unused)] eAppCapabilities1 = 1,

--- a/src/component.rs
+++ b/src/component.rs
@@ -1,4 +1,5 @@
-use std::ffi::{c_void, c_long};
+use std::os::raw::c_long;
+use std::ffi::c_void;
 use std::ptr::NonNull;
 use crate::memory::IMemoryManager;
 use crate::types::Variant;
@@ -8,42 +9,42 @@ use crate::connector::IConnector;
 pub struct IInitDoneBaseVTable<T> {
     #[cfg(target_os = "linux")]
     pub offset_linux: u64,
-    pub drop: unsafe extern "stdcall" fn(&mut T),
-    pub init: unsafe extern "stdcall" fn(&mut T, *mut c_void) -> bool,
-    pub set_mem_manager: unsafe extern "stdcall" fn(&mut T, *mut c_void) -> bool,
-    pub get_info: unsafe extern "stdcall" fn(&T) -> c_long,
-    pub done: unsafe extern "stdcall" fn(&mut T),
+    pub drop: unsafe extern "system" fn(&mut T),
+    pub init: unsafe extern "system" fn(&mut T, *mut c_void) -> bool,
+    pub set_mem_manager: unsafe extern "system" fn(&mut T, *mut c_void) -> bool,
+    pub get_info: unsafe extern "system" fn(&T) -> c_long,
+    pub done: unsafe extern "system" fn(&mut T),
 }
 
 #[repr(C)]
 pub struct ILanguageExtenderBaseVTable<T> {
     #[cfg(target_os = "linux")]
     pub offset_linux: u64,
-    pub drop: unsafe extern "stdcall" fn(&mut T),
-    pub register_extension_as: unsafe extern "stdcall" fn(&mut T, *mut *const u16) -> bool,
-    pub get_n_props: unsafe extern "stdcall" fn(&mut T) -> c_long,
-    pub find_prop: unsafe extern "stdcall" fn(&mut T, *const u16) -> c_long,
-    pub get_prop_name: unsafe extern "stdcall" fn(&T, c_long, c_long) -> *const u16,
-    pub get_prop_val: unsafe extern "stdcall" fn(&mut T, c_long, *mut Variant) -> bool,
-    pub set_prop_val: unsafe extern "stdcall" fn(&mut T, c_long, *mut Variant) -> bool,
-    pub is_prop_readable: unsafe extern "stdcall" fn(&mut T, c_long) -> bool,
-    pub is_prop_writeable: unsafe extern "stdcall" fn(&mut T, c_long) -> bool,
-    pub get_n_methods: unsafe extern "stdcall" fn(&mut T) -> c_long,
-    pub find_method: unsafe extern "stdcall" fn(&mut T, *const u16) -> c_long,
-    pub get_method_name: unsafe extern "stdcall" fn(&T, c_long, c_long) -> *const u16,
-    pub get_n_params: unsafe extern "stdcall" fn(&mut T, c_long) -> c_long,
-    pub get_param_def_value: unsafe extern "stdcall" fn(&mut T, c_long, c_long, *mut Variant) -> bool,
-    pub has_ret_val: unsafe extern "stdcall" fn(&mut T, c_long) -> bool,
-    pub call_as_proc: unsafe extern "stdcall" fn(&mut T, c_long, *mut Variant, c_long) -> bool,
-    pub call_as_func: unsafe extern "stdcall" fn(&mut T, c_long, *mut Variant, *mut Variant, c_long) -> bool,
+    pub drop: unsafe extern "system" fn(&mut T),
+    pub register_extension_as: unsafe extern "system" fn(&mut T, *mut *const u16) -> bool,
+    pub get_n_props: unsafe extern "system" fn(&mut T) -> c_long,
+    pub find_prop: unsafe extern "system" fn(&mut T, *const u16) -> c_long,
+    pub get_prop_name: unsafe extern "system" fn(&T, c_long, c_long) -> *const u16,
+    pub get_prop_val: unsafe extern "system" fn(&mut T, c_long, *mut Variant) -> bool,
+    pub set_prop_val: unsafe extern "system" fn(&mut T, c_long, *mut Variant) -> bool,
+    pub is_prop_readable: unsafe extern "system" fn(&mut T, c_long) -> bool,
+    pub is_prop_writeable: unsafe extern "system" fn(&mut T, c_long) -> bool,
+    pub get_n_methods: unsafe extern "system" fn(&mut T) -> c_long,
+    pub find_method: unsafe extern "system" fn(&mut T, *const u16) -> c_long,
+    pub get_method_name: unsafe extern "system" fn(&T, c_long, c_long) -> *const u16,
+    pub get_n_params: unsafe extern "system" fn(&mut T, c_long) -> c_long,
+    pub get_param_def_value: unsafe extern "system" fn(&mut T, c_long, c_long, *mut Variant) -> bool,
+    pub has_ret_val: unsafe extern "system" fn(&mut T, c_long) -> bool,
+    pub call_as_proc: unsafe extern "system" fn(&mut T, c_long, *mut Variant, c_long) -> bool,
+    pub call_as_func: unsafe extern "system" fn(&mut T, c_long, *mut Variant, *mut Variant, c_long) -> bool,
 }
 
 #[repr(C)]
 pub struct LocaleBaseVTable<T> {
     #[cfg(target_os = "linux")]
     pub offset_linux: u64,
-    pub drop: unsafe extern "stdcall" fn(&mut T),
-    pub set_locale: unsafe extern "stdcall" fn(&mut T, *const u16)
+    pub drop: unsafe extern "system" fn(&mut T),
+    pub set_locale: unsafe extern "system" fn(&mut T, *const u16)
 }
 
 #[repr(C)]

--- a/src/component.rs
+++ b/src/component.rs
@@ -1,4 +1,4 @@
-use std::ffi::c_void;
+use std::ffi::{c_void, c_long};
 use std::ptr::NonNull;
 use crate::memory::IMemoryManager;
 use crate::types::Variant;
@@ -8,42 +8,42 @@ use crate::connector::IConnector;
 pub struct IInitDoneBaseVTable<T> {
     #[cfg(target_os = "linux")]
     pub offset_linux: u64,
-    pub drop: unsafe extern "C" fn(&mut T),
-    pub init: unsafe extern "C" fn(&mut T, *mut c_void) -> bool,
-    pub set_mem_manager: unsafe extern "C" fn(&mut T, *mut c_void) -> bool,
-    pub get_info: unsafe extern "C" fn(&T) -> i64,
-    pub done: unsafe extern "C" fn(&mut T),
+    pub drop: unsafe extern "stdcall" fn(&mut T),
+    pub init: unsafe extern "stdcall" fn(&mut T, *mut c_void) -> bool,
+    pub set_mem_manager: unsafe extern "stdcall" fn(&mut T, *mut c_void) -> bool,
+    pub get_info: unsafe extern "stdcall" fn(&T) -> c_long,
+    pub done: unsafe extern "stdcall" fn(&mut T),
 }
 
 #[repr(C)]
 pub struct ILanguageExtenderBaseVTable<T> {
     #[cfg(target_os = "linux")]
     pub offset_linux: u64,
-    pub drop: unsafe extern "C" fn(&mut T),
-    pub register_extension_as: unsafe extern "C" fn(&mut T, *mut *const u16) -> bool,
-    pub get_n_props: unsafe extern "C" fn(&mut T) -> i64,
-    pub find_prop: unsafe extern "C" fn(&mut T, *const u16) -> i64,
-    pub get_prop_name: unsafe extern "C" fn(&T, i64, i64) -> *const u16,
-    pub get_prop_val: unsafe extern "C" fn(&mut T, i64, *mut Variant) -> bool,
-    pub set_prop_val: unsafe extern "C" fn(&mut T, i64, *mut Variant) -> bool,
-    pub is_prop_readable: unsafe extern "C" fn(&mut T, i64) -> bool,
-    pub is_prop_writeable: unsafe extern "C" fn(&mut T, i64) -> bool,
-    pub get_n_methods: unsafe extern "C" fn(&mut T) -> i64,
-    pub find_method: unsafe extern "C" fn(&mut T, *const u16) -> i64,
-    pub get_method_name: unsafe extern "C" fn(&T, i64, i64) -> *const u16,
-    pub get_n_params: unsafe extern "C" fn(&mut T, i64) -> i64,
-    pub get_param_def_value: unsafe extern "C" fn(&mut T, i64, i64, *mut Variant) -> bool,
-    pub has_ret_val: unsafe extern "C" fn(&mut T, i64) -> bool,
-    pub call_as_proc: unsafe extern "C" fn(&mut T, i64, *mut Variant, usize) -> bool,
-    pub call_as_func: unsafe extern "C" fn(&mut T, i64, *mut Variant, *mut Variant, usize) -> bool,
+    pub drop: unsafe extern "stdcall" fn(&mut T),
+    pub register_extension_as: unsafe extern "stdcall" fn(&mut T, *mut *const u16) -> bool,
+    pub get_n_props: unsafe extern "stdcall" fn(&mut T) -> c_long,
+    pub find_prop: unsafe extern "stdcall" fn(&mut T, *const u16) -> c_long,
+    pub get_prop_name: unsafe extern "stdcall" fn(&T, c_long, c_long) -> *const u16,
+    pub get_prop_val: unsafe extern "stdcall" fn(&mut T, c_long, *mut Variant) -> bool,
+    pub set_prop_val: unsafe extern "stdcall" fn(&mut T, c_long, *mut Variant) -> bool,
+    pub is_prop_readable: unsafe extern "stdcall" fn(&mut T, c_long) -> bool,
+    pub is_prop_writeable: unsafe extern "stdcall" fn(&mut T, c_long) -> bool,
+    pub get_n_methods: unsafe extern "stdcall" fn(&mut T) -> c_long,
+    pub find_method: unsafe extern "stdcall" fn(&mut T, *const u16) -> c_long,
+    pub get_method_name: unsafe extern "stdcall" fn(&T, c_long, c_long) -> *const u16,
+    pub get_n_params: unsafe extern "stdcall" fn(&mut T, c_long) -> c_long,
+    pub get_param_def_value: unsafe extern "stdcall" fn(&mut T, c_long, c_long, *mut Variant) -> bool,
+    pub has_ret_val: unsafe extern "stdcall" fn(&mut T, c_long) -> bool,
+    pub call_as_proc: unsafe extern "stdcall" fn(&mut T, c_long, *mut Variant, c_long) -> bool,
+    pub call_as_func: unsafe extern "stdcall" fn(&mut T, c_long, *mut Variant, *mut Variant, c_long) -> bool,
 }
 
 #[repr(C)]
 pub struct LocaleBaseVTable<T> {
     #[cfg(target_os = "linux")]
     pub offset_linux: u64,
-    pub drop: unsafe extern "C" fn(&mut T),
-    pub set_locale: unsafe extern "C" fn(&mut T, *const u16)
+    pub drop: unsafe extern "stdcall" fn(&mut T),
+    pub set_locale: unsafe extern "stdcall" fn(&mut T, *const u16)
 }
 
 #[repr(C)]
@@ -75,25 +75,25 @@ pub trait IComponentInit where Self: IComponentBase {
 pub trait IComponentBase {
     // IInitDoneBaseVTable
     fn init(&mut self) -> bool;
-    fn get_info(&self) -> i64;
+    fn get_info(&self) -> c_long;
     fn done(&mut self);
 
     // ILanguageExtenderBaseVTable
-    fn get_n_props(&self) -> i64;
-    fn find_prop(&self, prop_name: &str) -> i64;
-    fn get_prop_name(&self, prop_num: i64, prop_alias: i64) -> &str;
-    fn get_prop_val(&self, prop_num: i64, var_prop_val: &mut Variant) -> bool;
-    fn set_prop_val(&mut self, prop_num: i64, var_prop_val: &Variant) -> bool;
-    fn is_prop_readable(&self, prop_num: i64) -> bool;
-    fn is_prop_writeable(&self, prop_num: i64) -> bool;
-    fn get_n_methods(&self) -> i64;
-    fn find_method(&self, method_name: &str) -> i64;
-    fn get_method_name(&self, method_num: i64, method_alias: i64) -> &str;
-    fn get_n_params(&self, method_num: i64) -> i64;
-    fn get_param_def_value(&self, method_num: i64, param_num: i64, var_param_def_value: &mut Variant) -> bool;
-    fn has_ret_val(&self, method_num: i64) -> bool;
-    fn call_as_proc(&mut self, method_num: i64, params: Option<&mut [Variant]>) -> bool;
-    fn call_as_func(&mut self, method_num: i64, ret_vals: &mut Variant, params: Option<&mut [Variant]>) -> bool;
+    fn get_n_props(&self) -> c_long;
+    fn find_prop(&self, prop_name: &str) -> c_long;
+    fn get_prop_name(&self, prop_num: c_long, prop_alias: c_long) -> &str;
+    fn get_prop_val(&self, prop_num: c_long, var_prop_val: &mut Variant) -> bool;
+    fn set_prop_val(&mut self, prop_num: c_long, var_prop_val: &Variant) -> bool;
+    fn is_prop_readable(&self, prop_num: c_long) -> bool;
+    fn is_prop_writeable(&self, prop_num: c_long) -> bool;
+    fn get_n_methods(&self) -> c_long;
+    fn find_method(&self, method_name: &str) -> c_long;
+    fn get_method_name(&self, method_num: c_long, method_alias: c_long) -> &str;
+    fn get_n_params(&self, method_num: c_long) -> c_long;
+    fn get_param_def_value(&self, method_num: c_long, param_num: c_long, var_param_def_value: &mut Variant) -> bool;
+    fn has_ret_val(&self, method_num: c_long) -> bool;
+    fn call_as_proc(&mut self, method_num: c_long, params: Option<&mut [Variant]>) -> bool;
+    fn call_as_func(&mut self, method_num: c_long, ret_vals: &mut Variant, params: Option<&mut [Variant]>) -> bool;
 
     // LocaleBaseVTable
     fn set_locale(&mut self, loc: &str);

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -1,4 +1,4 @@
-use std::ffi::c_void;
+use std::ffi::{c_void, c_long};
 use std::ptr::NonNull;
 use widestring::U16CStr;
 use crate::memory::IMemoryManager;
@@ -13,8 +13,8 @@ enum Interface {
 
 #[repr(C)]
 struct IMessageBoxVTable {
-    confirm: unsafe extern "C" fn(&IMessageBox, *const u16, *mut Variant) -> bool,
-    alert: unsafe extern "C" fn(&IMessageBox, *const u16) -> bool,
+    confirm: unsafe extern "stdcall" fn(&IMessageBox, *const u16, *mut Variant) -> bool,
+    alert: unsafe extern "stdcall" fn(&IMessageBox, *const u16) -> bool,
 }
 
 #[repr(C)]
@@ -26,18 +26,18 @@ struct IMessageBox {
 struct IConnectorVTable {
     #[cfg(target_os = "linux")]
     pub offset_linux: u64,
-    _drop: unsafe extern "C" fn(&mut IConnector),
-    add_error: unsafe extern "C" fn(&mut IConnector, u16, *const u16, *const u16, i64) -> bool,
-    read: unsafe extern "C" fn(&mut IConnector, *const u16, *const Variant, *mut u64, *const *const u16) -> bool,
-    write: unsafe extern "C" fn(&mut IConnector, *const u16, *const Variant) -> bool,
-    register_profile_as: unsafe extern "C" fn(&mut IConnector, *const u16) -> bool,
-    set_event_buffer_depths: unsafe extern "C" fn(&mut IConnector, u64) -> bool,
-    get_event_buffer_depths: unsafe extern "C" fn(&mut IConnector) -> u64,
-    external_event: unsafe extern "C" fn(&mut IConnector, *const u16, *const u16, *const u16) -> bool,
-    clean_event_buffer: unsafe extern "C" fn(&mut IConnector),
-    set_status_line: unsafe extern "C" fn(&mut IConnector, *const u16) -> bool,
-    reset_status_line: unsafe extern "C" fn(&mut IConnector),
-    get_interface: unsafe extern "C" fn(&IConnector, Interface) -> *const c_void,
+    _drop: unsafe extern "stdcall" fn(&mut IConnector),
+    add_error: unsafe extern "stdcall" fn(&mut IConnector, u16, *const u16, *const u16, c_long) -> bool,
+    read: unsafe extern "stdcall" fn(&mut IConnector, *const u16, *const Variant, *mut c_long, *const *const u16) -> bool,
+    write: unsafe extern "stdcall" fn(&mut IConnector, *const u16, *const Variant) -> bool,
+    register_profile_as: unsafe extern "stdcall" fn(&mut IConnector, *const u16) -> bool,
+    set_event_buffer_depths: unsafe extern "stdcall" fn(&mut IConnector, c_long) -> bool,
+    get_event_buffer_depths: unsafe extern "stdcall" fn(&mut IConnector) -> c_long,
+    external_event: unsafe extern "stdcall" fn(&mut IConnector, *const u16, *const u16, *const u16) -> bool,
+    clean_event_buffer: unsafe extern "stdcall" fn(&mut IConnector),
+    set_status_line: unsafe extern "stdcall" fn(&mut IConnector, *const u16) -> bool,
+    reset_status_line: unsafe extern "stdcall" fn(&mut IConnector),
+    get_interface: unsafe extern "stdcall" fn(&IConnector, Interface) -> *const c_void,
 }
 
 #[repr(C)]
@@ -46,16 +46,16 @@ pub struct IConnector {
 }
 
 impl IConnector {
-    pub fn add_error(&mut self, code: u16, source: &str, descr: &str, scode: i64, manager: &mut IMemoryManager) -> bool {
+    pub fn add_error(&mut self, code: u16, source: &str, descr: &str, scode: c_long, manager: &mut IMemoryManager) -> bool {
         let source = manager.copy_utf16_str(source);
         let descr = manager.copy_utf16_str(descr);
         unsafe { (self.vtable.as_mut().add_error)(self, code, source, descr, scode) }
     }
 
-    pub fn read(&mut self, prop_name: &str, value: &mut Variant, error: &mut u64, error_description: &mut String, manager: &mut IMemoryManager) -> bool {
+    pub fn read(&mut self, prop_name: &str, value: &mut Variant, error: &mut c_long, error_description: &mut String, manager: &mut IMemoryManager) -> bool {
         let prop_name = manager.copy_utf16_str(prop_name);
         let value = value as *mut Variant;
-        let error = error as *mut u64;
+        let error = error as *mut c_long;
         let mut error_description_ptr = std::ptr::null();
 
         let result = unsafe { (self.vtable.as_mut().read)(self, prop_name, value, error, &error_description_ptr) };
@@ -76,11 +76,11 @@ impl IConnector {
         unsafe { (self.vtable.as_mut().register_profile_as)(self, profile_name) }
     }
 
-    pub fn set_event_buffer_depths(&mut self, depths: u64) -> bool {
+    pub fn set_event_buffer_depths(&mut self, depths: c_long) -> bool {
         unsafe { (self.vtable.as_mut().set_event_buffer_depths)(self, depths) }
     }
 
-    pub fn get_event_buffer_depths(&mut self) -> u64 {
+    pub fn get_event_buffer_depths(&mut self) -> c_long {
         unsafe { (self.vtable.as_mut().get_event_buffer_depths)(self) }
     }
 
@@ -133,7 +133,7 @@ impl IConnector {
         }
 
         let text = manager.copy_utf16_str(text);
-        let interface = unsafe { &mut *(interface as *mut IMessageBox) };
+        let interface = unsafe { &mut *(((interface as usize) - std::mem::size_of::<c_long>()) as *mut IMessageBox) };
         let result = unsafe { (interface.vtable.as_mut().alert)(interface, text) };
         if result {
             Ok(())
@@ -150,7 +150,7 @@ impl IConnector {
             return Err(())
         }
 
-        let interface = unsafe { &mut *(interface as *mut IPlatformInfo) };
+        let interface = unsafe { &mut *(((interface as usize) - std::mem::size_of::<c_long>()) as *mut IPlatformInfo) };
         let result = unsafe { (interface.vtable.as_mut().get_platform_info)(interface) };
         if result.is_null() {
             return Err(())

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -117,7 +117,7 @@ impl IConnector {
 
         let mut ret= Variant::empty();
         let text = manager.copy_utf16_str(text);
-        let interface = unsafe { &mut *(interface as *mut IMessageBox) };
+        let interface = unsafe { &mut *(((interface as usize) - std::mem::size_of::<usize>()) as *mut IMessageBox) };
         let result = unsafe { (interface.vtable.as_mut().confirm)(interface, text, &mut ret as *mut Variant) };
         if result {
             Ok(ret)

--- a/src/info.rs
+++ b/src/info.rs
@@ -3,7 +3,7 @@ use widestring::U16CStr;
 
 #[repr(C)]
 pub(crate) struct PlatformInfoVTable {
-    pub(crate) get_platform_info: unsafe extern "C" fn(&IPlatformInfo) -> *const AppInfoInner,
+    pub(crate) get_platform_info: unsafe extern "stdcall" fn(&IPlatformInfo) -> *const AppInfoInner,
 }
 
 #[repr(C)]

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,6 +1,6 @@
 use std::ffi::c_void;
 use std::ptr::NonNull;
-use std::os::raw::{c_long, c_ulong};
+use std::os::raw::c_ulong;
 
 
 #[repr(C)]

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -50,7 +50,7 @@ impl IMemoryManager {
             if !value.is_empty() {
                 std::ptr::copy(data_ptr, ptr, value.len() + 1);
             }
-            std::ptr::write(((ptr as c_long) + (value.len() as c_long)) as *mut u8, 0x00 as u8);
+            std::ptr::write(((ptr as usize) + value.len()) as *mut u8, 0x00 as u8);
         }
         ptr
     }
@@ -64,7 +64,7 @@ impl IMemoryManager {
             if !value.is_empty() {
                 std::ptr::copy(data_ptr, ptr, data.len() + 1);
             }
-            std::ptr::write(((ptr as c_long) + (data.len() as c_long) * 2) as *mut u16, 0x0000 as u16);
+            std::ptr::write(((ptr as usize) + data.len() * 2) as *mut u16, 0x0000 as u16);
         }
         ptr
     }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,14 +1,15 @@
-use std::ffi::{c_void, c_long, c_ulong};
+use std::ffi::c_void;
 use std::ptr::NonNull;
+use std::os::raw::{c_long, c_ulong};
 
 
 #[repr(C)]
 pub struct IMemoryManagerVTable {
     #[cfg(target_os = "linux")]
     offset_linux: u64,
-    _drop: unsafe extern "stdcall" fn(&mut IMemoryManager),
-    _alloc_memory: unsafe extern "stdcall" fn(&mut IMemoryManager, *mut *const c_void, c_ulong) -> bool,
-    _free_memory: unsafe extern "stdcall" fn(&mut IMemoryManager, *mut *const c_void),
+    _drop: unsafe extern "system" fn(&mut IMemoryManager),
+    _alloc_memory: unsafe extern "system" fn(&mut IMemoryManager, *mut *const c_void, c_ulong) -> bool,
+    _free_memory: unsafe extern "system" fn(&mut IMemoryManager, *mut *const c_void),
 }
 
 pub struct IMemoryManager {

--- a/src/types.rs
+++ b/src/types.rs
@@ -327,15 +327,9 @@ variant_from!(bool, b_val, VariableType::VTYPE_BOOL);
 variant_from!(u8, ull_val, VariableType::VTYPE_UI1);
 variant_from!(u16, ull_val, VariableType::VTYPE_UI2);
 variant_from!(u32, ull_val, VariableType::VTYPE_UI4);
-#[cfg(target_arch = "x86_64")]
-variant_from!(u64, ull_val, VariableType::VTYPE_UI8);
-#[cfg(target_arch = "x86")]
 variant_from!(u64, ull_val, VariableType::VTYPE_UI4);
 variant_from!(i8, ll_val, VariableType::VTYPE_I1);
 variant_from!(i16, ll_val, VariableType::VTYPE_I2);
 variant_from!(i32, ll_val, VariableType::VTYPE_I4);
-#[cfg(target_arch = "x86_64")]
-variant_from!(i64, ll_val, VariableType::VTYPE_I8);
-#[cfg(target_arch = "x86")]
 variant_from!(i64, ll_val, VariableType::VTYPE_I4);
 variant_from!(f64, dbl_val, VariableType::VTYPE_R8);

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,5 @@
+use std::os::raw::{c_long, c_float, c_double};
+
 use libc::{tm, c_char};
 use crate::component::IComponentInit;
 
@@ -49,9 +51,9 @@ pub union VariantUnion {
     ul_val: u32,
     ull_val: u64,
     err_code: i32,
-    h_res: i64,
-    flt_val: f64,
-    dbl_val: f64,
+    h_res: c_long,
+    flt_val: c_float,
+    dbl_val: c_double,
     b_val: bool,
     ch_val: i8,
     wch_val: u16,
@@ -325,9 +327,15 @@ variant_from!(bool, b_val, VariableType::VTYPE_BOOL);
 variant_from!(u8, ull_val, VariableType::VTYPE_UI1);
 variant_from!(u16, ull_val, VariableType::VTYPE_UI2);
 variant_from!(u32, ull_val, VariableType::VTYPE_UI4);
+#[cfg(target_arch = "x86_64")]
 variant_from!(u64, ull_val, VariableType::VTYPE_UI8);
+#[cfg(target_arch = "x86")]
+variant_from!(u64, ull_val, VariableType::VTYPE_UI4);
 variant_from!(i8, ll_val, VariableType::VTYPE_I1);
 variant_from!(i16, ll_val, VariableType::VTYPE_I2);
 variant_from!(i32, ll_val, VariableType::VTYPE_I4);
+#[cfg(target_arch = "x86_64")]
 variant_from!(i64, ll_val, VariableType::VTYPE_I8);
+#[cfg(target_arch = "x86")]
+variant_from!(i64, ll_val, VariableType::VTYPE_I4);
 variant_from!(f64, dbl_val, VariableType::VTYPE_R8);


### PR DESCRIPTION
Fixes https://github.com/tuplecats/rust-native-1c/issues/2

1. Тип long в Windows - имеет длину 4 байта, в Linux - 8. Соответственно нужно использовать не u64, а c_long который это учитывает
2. Windows использует соглашение stdcall, а Linux - cdecl; тут пока изменено на stdcall, но нужно сделать это платформозависимым
3. IMessageBox и IPlatformInfo - там тоже нужен "оффсет" для `this`, по крайней мере для Windows. Нужно проверить на Linux.
