### PR TITLE
Fix get_interface()

### DIFF
--- a/src/connector.rs
+++ b/src/connector.rs
@@ -5,7 +5,7 @@ use crate::memory::IMemoryManager;
 use crate::types::Variant;
 use crate::info::{AppInfo, IPlatformInfo};
 
-#[repr(u8)]
+#[repr(u32)]
 enum Interface {
     IMsgBox = 0,
     IPlatformInfo = 1,


### PR DESCRIPTION
Interface is enum in C++, and enum size (for small values like here) is 4 bytes usually
This fixes get_interface() not working